### PR TITLE
More precise index out of bounds check

### DIFF
--- a/src/plugins/MemCheck.cpp
+++ b/src/plugins/MemCheck.cpp
@@ -29,43 +29,26 @@ void MemCheck::instructionExecuted(const WorkItem *workItem,
                                    const llvm::Instruction *instruction,
                                    const TypedValue& result)
 {
-  if (auto gep = llvm::dyn_cast<llvm::GetElementPtrInst>(instruction))
-  {
-    // Iterate through GEP indices
-    const llvm::Type *ptrType = gep->getPointerOperandType();
-    for (auto opIndex = gep->idx_begin(); opIndex != gep->idx_end(); opIndex++)
+    // Check static array bounds if load or store is executed
+    const llvm::Value *PtrOp = nullptr;
+
+    if(const llvm::LoadInst *LI = llvm::dyn_cast<llvm::LoadInst>(instruction))
     {
-      int64_t index = workItem->getOperand(opIndex->get()).getSInt();
-
-      if (ptrType->isArrayTy())
-      {
-        // Check index doesn't exceed size of array
-        uint64_t size = ptrType->getArrayNumElements();
-        if ((uint64_t)index >= size)
-        {
-          ostringstream info;
-          info << "Index ("
-               << index << ") exceeds static array size ("
-               << size << ")";
-          m_context->logError(info.str().c_str());
-        }
-
-        ptrType = ptrType->getArrayElementType();
-      }
-      else if (ptrType->isPointerTy())
-      {
-        ptrType = ptrType->getPointerElementType();
-      }
-      else if (ptrType->isVectorTy())
-      {
-        ptrType = ptrType->getVectorElementType();
-      }
-      else if (ptrType->isStructTy())
-      {
-        ptrType = ptrType->getStructElementType(index);
-      }
+        PtrOp = LI->getPointerOperand();
     }
-  }
+    else if(const llvm::StoreInst *SI = llvm::dyn_cast<llvm::StoreInst>(instruction))
+    {
+        PtrOp = SI->getPointerOperand();
+    }
+    else
+    {
+        return;
+    }
+
+    if(auto GEPI = llvm::dyn_cast<llvm::GetElementPtrInst>(PtrOp))
+    {
+        checkArrayAccess(workItem, GEPI);
+    }
 }
 
 void MemCheck::memoryAtomicLoad(const Memory *memory,
@@ -132,6 +115,46 @@ void MemCheck::memoryUnmap(const Memory *memory, size_t address,
       return;
     }
   }
+}
+
+void MemCheck::checkArrayAccess(const WorkItem *workItem, const llvm::GetElementPtrInst *GEPI) const
+{
+    // Iterate through GEPI indices
+    const llvm::Type *ptrType = GEPI->getPointerOperandType();
+
+    for(auto opIndex = GEPI->idx_begin(); opIndex != GEPI->idx_end(); opIndex++)
+    {
+        int64_t index = workItem->getOperand(opIndex->get()).getSInt();
+
+        if(ptrType->isArrayTy())
+        {
+            // Check index doesn't exceed size of array
+            uint64_t size = ptrType->getArrayNumElements();
+
+            if((uint64_t)index >= size)
+            {
+                ostringstream info;
+                info << "Index ("
+                    << index << ") exceeds static array size ("
+                    << size << ")";
+                m_context->logError(info.str().c_str());
+            }
+
+            ptrType = ptrType->getArrayElementType();
+        }
+        else if(ptrType->isPointerTy())
+        {
+            ptrType = ptrType->getPointerElementType();
+        }
+        else if(ptrType->isVectorTy())
+        {
+            ptrType = ptrType->getVectorElementType();
+        }
+        else if(ptrType->isStructTy())
+        {
+            ptrType = ptrType->getStructElementType(index);
+        }
+    }
 }
 
 void MemCheck::checkLoad(const Memory *memory,

--- a/src/plugins/MemCheck.h
+++ b/src/plugins/MemCheck.h
@@ -8,6 +8,11 @@
 
 #include "core/Plugin.h"
 
+namespace llvm
+{
+    class GetElementPtrInst;
+}
+
 namespace oclgrind
 {
   class MemCheck : public Plugin
@@ -43,6 +48,7 @@ namespace oclgrind
                              const void *ptr) override;
 
   private:
+    void checkArrayAccess(const WorkItem *workItem, const llvm::GetElementPtrInst *GEPI) const;
     void checkLoad(const Memory *memory, size_t address, size_t size) const;
     void checkStore(const Memory *memory, size_t address, size_t size) const;
     void logInvalidAccess(bool read, unsigned addrSpace,

--- a/tests/kernels/TESTS
+++ b/tests/kernels/TESTS
@@ -45,8 +45,10 @@ data-race/uniform_write_race
 memcheck/async_copy_out_of_bounds
 memcheck/atomic_out_of_bounds
 memcheck/dereference_null
+memcheck/fake_out_of_bounds
 memcheck/read_out_of_bounds
 memcheck/read_write_only_memory
+memcheck/static_array
 memcheck/static_array_padded_struct
 memcheck/write_out_of_bounds
 memcheck/write_read_only_memory

--- a/tests/kernels/memcheck/fake_out_of_bounds.cl
+++ b/tests/kernels/memcheck/fake_out_of_bounds.cl
@@ -1,0 +1,12 @@
+struct S0 {
+    uchar f[1];
+    ulong g[4];
+};
+
+__kernel void entry(__global ulong *result) {
+    struct S0 s = {{1}, {2,3,4,5}};
+    struct S0 t = s;
+
+    volatile int i = 0;
+    *result = t.g[i];
+}

--- a/tests/kernels/memcheck/fake_out_of_bounds.ref
+++ b/tests/kernels/memcheck/fake_out_of_bounds.ref
@@ -1,0 +1,2 @@
+EXACT Argument 'result': 8 bytes
+EXACT   result[0] = 2

--- a/tests/kernels/memcheck/fake_out_of_bounds.sim
+++ b/tests/kernels/memcheck/fake_out_of_bounds.sim
@@ -1,0 +1,6 @@
+fake_out_of_bounds.cl
+entry
+1 1 1
+1 1 1
+
+<size=8 fill=0 dump>

--- a/tests/kernels/memcheck/static_array.cl
+++ b/tests/kernels/memcheck/static_array.cl
@@ -1,0 +1,13 @@
+struct S
+{
+  int a;
+  char b[2];
+};
+
+kernel void static_array(global char *output)
+{
+  volatile struct S s = {-1, {42, 7}};
+  int i = get_global_id(0);
+  s.b[i] = i;
+  output[i] = s.b[i];
+}

--- a/tests/kernels/memcheck/static_array.ref
+++ b/tests/kernels/memcheck/static_array.ref
@@ -1,0 +1,10 @@
+ERROR exceeds static array size
+ERROR exceeds static array size
+ERROR exceeds static array size
+ERROR exceeds static array size
+
+EXACT Argument 'output': 4 bytes
+EXACT   output[0] = 0
+EXACT   output[1] = 1
+MATCH   output[2] =
+MATCH   output[3] =

--- a/tests/kernels/memcheck/static_array.sim
+++ b/tests/kernels/memcheck/static_array.sim
@@ -1,0 +1,6 @@
+static_array.cl
+static_array
+4 1 1
+4 1 1
+
+<size=4 fill=0 dump>


### PR DESCRIPTION
This pull request improves the check for out of bound arrays accesses. The previous check did always evaluate the indices of the getelementptr instruction which leads to false positives. The gep instruction can be used to compute addresses which would allegedly violate the static bounds of an array without introducing undefined behaviour (See http://llvm.org/docs/GetElementPtr.html#what-happens-if-an-array-index-is-out-of-bounds and the test memcheck/fake_out_of_bounds).

The behaviour of the check is changed such that now the gep instruction is only evaluated if it is used as operand in a load or store instruction. Only in this cases the address is actually used to access memory which could create an invalid access.