### PR TITLE
Ignore casts when checking static array bounds

### DIFF
--- a/src/plugins/MemCheck.cpp
+++ b/src/plugins/MemCheck.cpp
@@ -45,7 +45,7 @@ void MemCheck::instructionExecuted(const WorkItem *workItem,
     return;
   }
 
-  if (auto GEPI = llvm::dyn_cast<llvm::GetElementPtrInst>(PtrOp))
+  if (auto GEPI = llvm::dyn_cast<llvm::GetElementPtrInst>(PtrOp->stripPointerCasts()))
   {
     checkArrayAccess(workItem, GEPI);
   }

--- a/tests/kernels/TESTS
+++ b/tests/kernels/TESTS
@@ -44,6 +44,7 @@ data-race/local_write_write_race
 data-race/uniform_write_race
 memcheck/async_copy_out_of_bounds
 memcheck/atomic_out_of_bounds
+memcheck/casted_static_array
 memcheck/dereference_null
 memcheck/fake_out_of_bounds
 memcheck/read_out_of_bounds

--- a/tests/kernels/memcheck/casted_static_array.cl
+++ b/tests/kernels/memcheck/casted_static_array.cl
@@ -1,0 +1,31 @@
+void transparent_crc_no_string(ulong *p1, ulong p2) { *p1 += p2; }
+int get_linear_global_id() {
+  return (get_global_id(2) * get_global_size(1) + get_global_id(1)) *
+             get_global_size(0) +
+         get_global_id(0);
+}
+union U5 {
+  short f0;
+  int f3;
+};
+struct S6 {
+  union U5 g_75[5][7][2];
+  union U5 **g_91[78];
+};
+__kernel void casted_static_array(__global ulong *p1) {
+  int i, j, k;
+  struct S6 c_864;
+  struct S6 *p_863 = &c_864;
+  union U5 *p_863_6;
+  struct S6 c_865 = {{{{{0xD54EL}}}}, {&p_863_6}};
+  c_864 = c_865;
+  ulong crc64_context = i = 0;
+  for (; i < 9; i++) {
+    j = 0;
+    {
+      k = 0;
+      { transparent_crc_no_string(&crc64_context, p_863->g_75[i][j][k].f0); }
+    }
+  }
+  p1[get_linear_global_id()] = crc64_context;
+}

--- a/tests/kernels/memcheck/casted_static_array.ref
+++ b/tests/kernels/memcheck/casted_static_array.ref
@@ -1,0 +1,4 @@
+ERROR exceeds static array size
+
+EXACT Argument 'output': 8 bytes
+MATCH   output[0] =

--- a/tests/kernels/memcheck/casted_static_array.sim
+++ b/tests/kernels/memcheck/casted_static_array.sim
@@ -1,0 +1,6 @@
+casted_static_array.cl
+casted_static_array
+1 1 1
+1 1 1
+
+<size=8 fill=0 dump>


### PR DESCRIPTION
I figured out that Oclgrind misses some static out-of-bound accesses due to the SROA optimisation. In these situations the GEP value is casted before the load/store operation which causes Oclgrind not to perform a check.
I added "stripPointerCasts()" to ignore all cast between load/store and GEP instruction.