### PR TITLE
More precise check for vector arguments

### DIFF
--- a/src/plugins/Uninitialized.h
+++ b/src/plugins/Uninitialized.h
@@ -237,6 +237,7 @@ namespace oclgrind
             static bool isCleanValue(TypedValue v);
             static bool isCleanValue(TypedValue v, unsigned offset);
             void setGlobalValue(const llvm::Value *V, TypedValue SV);
+            static void shadowOr(TypedValue v1, TypedValue v2);
 
         private:
             ShadowMemory *m_globalMemory;
@@ -308,5 +309,6 @@ namespace oclgrind
             void SimpleOrAtomic(const WorkItem *workItem, const llvm::CallInst *CI);
             void storeShadowMemory(unsigned addrSpace, size_t address, TypedValue SM,
                                    const WorkItem *workItem = NULL, const WorkGroup *workGroup = NULL, bool unchecked = false);
+            void VectorOr(const WorkItem *workItem, const llvm::Instruction *I);
     };
 }

--- a/tests/kernels/TESTS
+++ b/tests/kernels/TESTS
@@ -22,6 +22,7 @@ atomics/atomic_same_workitem
 barrier/barrier_different_instructions
 barrier/barrier_divergence
 bugs/byval_function_argument
+bugs/false_warning_vector_argument
 bugs/gvn_arbitrary_integers
 bugs/kernel_struct_argument
 bugs/many_alloca

--- a/tests/kernels/bugs/false_warning_vector_argument.cl
+++ b/tests/kernels/bugs/false_warning_vector_argument.cl
@@ -1,0 +1,8 @@
+kernel void false_warning_vector_argument(int16 arg, global int8 *res)
+{
+    int8 v = (int8)(1,2,3,4,5,6,7,8);
+
+    int16 add = arg + v.s0011223344556677;
+
+    *res = add.lo;
+}

--- a/tests/kernels/bugs/false_warning_vector_argument.ref
+++ b/tests/kernels/bugs/false_warning_vector_argument.ref
@@ -1,0 +1,9 @@
+EXACT Argument 'res': 32 bytes
+EXACT   res[0] = 1
+EXACT   res[1] = 1
+EXACT   res[2] = 2
+EXACT   res[3] = 2
+EXACT   res[4] = 3
+EXACT   res[5] = 3
+EXACT   res[6] = 4
+EXACT   res[7] = 4

--- a/tests/kernels/bugs/false_warning_vector_argument.sim
+++ b/tests/kernels/bugs/false_warning_vector_argument.sim
@@ -1,0 +1,7 @@
+false_warning_vector_argument.cl
+false_warning_vector_argument
+1 1 1
+1 1 1
+
+<size=64 fill=0>
+<size=32 fill=0 dump>


### PR DESCRIPTION
I discovered that there might be situations where the compiler seems to choose a larger vector size and fills it with `undef` values.
Since until now vector elements where not handled separately this lead to false positive warnings in cases where the `undef` elements were actually not used.

For instance:
```
%115 = add <16 x i32> %114, <i32 -162813643, i32 -162813643, i32 -162813643, i32 -162813643, i32 -162813643, i32 -162813643, i32 -162813643, i32 -162813643, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
%116 = shufflevector <16 x i32> %115, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
store <8 x i32> %116, <8 x i32>* %0, align 32, !tbaa !16
```

The previous handling caused all elements of the shadow vector for instruction %115 to be poisoned which in turn emitted a warning for the store instruction.
But in fact the first 8 elements of the vector are well-defined and only these elements are stored.