### PR TITLE
Kill program if Oclgrind is killed

### DIFF
--- a/src/runtime/oclgrind
+++ b/src/runtime/oclgrind
@@ -141,10 +141,10 @@ fi
 LIBDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../lib"
 if [ "$(uname -s)" == "Darwin" ]
 then
-  DYLD_LIBRARY_PATH=$LIBDIR:$DYLD_LIBRARY_PATH \
+  exec env DYLD_LIBRARY_PATH=$LIBDIR:$DYLD_LIBRARY_PATH \
     DYLD_INSERT_LIBRARIES=$LIBDIR/liboclgrind-rt.dylib \
     DYLD_FORCE_FLAT_NAMESPACE=1 "$@"
 else
-  LD_LIBRARY_PATH=$LIBDIR:$LD_LIBRARY_PATH \
+  exec env LD_LIBRARY_PATH=$LIBDIR:$LD_LIBRARY_PATH \
     LD_PRELOAD=$LIBDIR/liboclgrind-rt.so "$@"
 fi


### PR DESCRIPTION
I notices the the oclgrind wrapper script does not forward the SIGTERM command to the actual executable. For instance, trying to kill the oclgrind process in htop only results in the bash being killed but the actual executable continues to run. (Ctrl-C does kill both but I've read that it works slightly different than just sending SIGTERM.)
I added exec before the call to the actual executable in the oclgrind script which solves the problem. The bash is replaced by the actual program and thus there is only one process which has to be killed.