### PR TITLE
Fix MemCheck mapped memory check

### DIFF
--- a/src/plugins/MemCheck.cpp
+++ b/src/plugins/MemCheck.cpp
@@ -175,6 +175,8 @@ void MemCheck::checkLoad(const Memory *memory,
   {
     m_context->logError("Invalid read from write-only buffer");
   }
+  
+  if (memory->getAddressSpace() == AddrSpaceLocal || memory->getAddressSpace() == AddrSpacePrivate) return;
 
   // Check if memory location is currently mapped for writing
   for (auto region = m_mapRegions.begin();
@@ -203,6 +205,8 @@ void MemCheck::checkStore(const Memory *memory,
   {
     m_context->logError("Invalid write to read-only buffer");
   }
+
+  if (memory->getAddressSpace() == AddrSpaceLocal || memory->getAddressSpace() == AddrSpacePrivate) return;
 
   // Check if memory location is currently mapped
   for (auto region = m_mapRegions.begin();


### PR DESCRIPTION
I've noticed that when a kernel is using __private (indexed) or __local memory oclgrind reports the following false positives...

* "Invalid write to mapped buffer"
* "Invalid read from buffer mapped for writing"

This request attempts to fix this by simply not checking for mapped memory if address space is private/local.
