### PR TITLE
Fix atomic_min/max

### DIFF
--- a/src/core/Memory.cpp
+++ b/src/core/Memory.cpp
@@ -93,8 +93,6 @@ size_t Memory::allocateBuffer(size_t size, cl_mem_flags flags,
 
 template uint32_t Memory::atomic(AtomicOp op, size_t address, uint32_t value);
 template int32_t Memory::atomic(AtomicOp op, size_t address, int32_t value);
-template uint64_t Memory::atomic(AtomicOp op, size_t address, uint64_t value);
-template int64_t Memory::atomic(AtomicOp op, size_t address, int64_t value);
 
 template<typename T>
 T Memory::atomic(AtomicOp op, size_t address, T value)

--- a/src/core/Memory.cpp
+++ b/src/core/Memory.cpp
@@ -91,7 +91,13 @@ size_t Memory::allocateBuffer(size_t size, cl_mem_flags flags,
   return address;
 }
 
-uint32_t Memory::atomic(AtomicOp op, size_t address, uint32_t value)
+template uint32_t Memory::atomic(AtomicOp op, size_t address, uint32_t value);
+template int32_t Memory::atomic(AtomicOp op, size_t address, int32_t value);
+template uint64_t Memory::atomic(AtomicOp op, size_t address, uint64_t value);
+template int64_t Memory::atomic(AtomicOp op, size_t address, int64_t value);
+
+template<typename T>
+T Memory::atomic(AtomicOp op, size_t address, T value)
 {
   m_context->notifyMemoryAtomicLoad(this, op, address, 4);
   m_context->notifyMemoryAtomicStore(this, op, address, 4);
@@ -105,12 +111,12 @@ uint32_t Memory::atomic(AtomicOp op, size_t address, uint32_t value)
   // Get buffer
   size_t offset = extractOffset(address);
   Buffer *buffer = m_memory[extractBuffer(address)];
-  uint32_t *ptr = (uint32_t*)(buffer->data + offset);
+  T *ptr = (T*)(buffer->data + offset);
 
   if (m_addressSpace == AddrSpaceGlobal)
     ATOMIC_MUTEX(offset).lock();
 
-  uint32_t old = *ptr;
+  T old = *ptr;
   switch(op)
   {
   case AtomicAdd:

--- a/src/core/Memory.h
+++ b/src/core/Memory.h
@@ -28,7 +28,7 @@ namespace oclgrind
 
     size_t allocateBuffer(size_t size, cl_mem_flags flags=0,
                           const uint8_t *initData = NULL);
-    uint32_t atomic(AtomicOp op, size_t address, uint32_t value = 0);
+    template<typename T> T atomic(AtomicOp op, size_t address, T value = 0);
     uint32_t atomicCmpxchg(size_t address, uint32_t cmp, uint32_t value);
     void clear();
     size_t createHostBuffer(size_t size, void *ptr, cl_mem_flags flags=0);

--- a/src/core/WorkItemBuiltins.cpp
+++ b/src/core/WorkItemBuiltins.cpp
@@ -328,7 +328,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_dec");
       }
-      uint32_t old = memory->atomic(AtomicDec, address);
+      uint32_t old = memory->atomic<uint32_t>(AtomicDec, address);
       result.setUInt(old);
     }
 
@@ -342,7 +342,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_dec");
       }
-      uint32_t old = memory->atomic(AtomicInc, address);
+      uint32_t old = memory->atomic<uint32_t>(AtomicInc, address);
       result.setUInt(old);
     }
 
@@ -356,8 +356,17 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_max");
       }
-      uint32_t old = memory->atomic(AtomicMax, address, UARG(1));
-      result.setUInt(old);
+      bool is_signed = overload.back() == 'i';
+      if (is_signed)
+      {
+        int32_t old = memory->atomic<int32_t>(AtomicMax, address, SARG(1));
+        result.setSInt(old);
+      }
+      else
+      {
+        uint32_t old = memory->atomic<uint32_t>(AtomicMax, address, UARG(1));
+        result.setUInt(old);
+      }
     }
 
     DEFINE_BUILTIN(atomic_min)
@@ -370,8 +379,17 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_min");
       }
-      uint32_t old = memory->atomic(AtomicMin, address, UARG(1));
-      result.setUInt(old);
+      bool is_signed = overload.back() == 'i';
+      if (is_signed)
+      {
+        int32_t old = memory->atomic<int32_t>(AtomicMin, address, SARG(1));
+        result.setSInt(old);
+      }
+      else
+      {
+        uint32_t old = memory->atomic<uint32_t>(AtomicMin, address, UARG(1));
+        result.setUInt(old);
+      }
     }
 
     DEFINE_BUILTIN(atomic_or)

--- a/src/core/WorkItemBuiltins.cpp
+++ b/src/core/WorkItemBuiltins.cpp
@@ -286,7 +286,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_add");
       }
-      uint32_t old = memory->atomic(AtomicAdd, address, UARG(1));
+      uint32_t old = memory->atomic<uint32_t>(AtomicAdd, address, UARG(1));
       result.setUInt(old);
     }
 
@@ -300,7 +300,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_and");
       }
-      uint32_t old = memory->atomic(AtomicAnd, address, UARG(1));
+      uint32_t old = memory->atomic<uint32_t>(AtomicAnd, address, UARG(1));
       result.setUInt(old);
     }
 
@@ -402,7 +402,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_or");
       }
-      uint32_t old = memory->atomic(AtomicOr, address, UARG(1));
+      uint32_t old = memory->atomic<uint32_t>(AtomicOr, address, UARG(1));
       result.setUInt(old);
     }
 
@@ -416,7 +416,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_sub");
       }
-      uint32_t old = memory->atomic(AtomicSub, address, UARG(1));
+      uint32_t old = memory->atomic<uint32_t>(AtomicSub, address, UARG(1));
       result.setUInt(old);
     }
 
@@ -430,7 +430,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_xchg");
       }
-      uint32_t old = memory->atomic(AtomicXchg, address, UARG(1));
+      uint32_t old = memory->atomic<uint32_t>(AtomicXchg, address, UARG(1));
       result.setUInt(old);
     }
 
@@ -444,7 +444,7 @@ namespace oclgrind
       if ((address & 0x3) != 0) {
         workItem->m_context->logError("Unaligned address on atomic_xor");
       }
-      uint32_t old = memory->atomic(AtomicXor, address, UARG(1));
+      uint32_t old = memory->atomic<uint32_t>(AtomicXor, address, UARG(1));
       result.setUInt(old);
     }
 


### PR DESCRIPTION
The following function was producing wrong results for signed values and min/max operators
`uint32_t Memory::atomic(AtomicOp op, size_t address, uint32_t value);`

This merge request is converting the method to a template
`template<typename T> T Memory::atomic(AtomicOp op, size_t address, T value);`
with four forward declared versions...
```
template uint32_t Memory::atomic(AtomicOp op, size_t address, uint32_t value);
template int32_t Memory::atomic(AtomicOp op, size_t address, int32_t value);
template uint64_t Memory::atomic(AtomicOp op, size_t address, uint64_t value);
template int64_t Memory::atomic(AtomicOp op, size_t address, int64_t value);
```

In WorkitemsBuiltins.cpp I am trying to determine where the type is signed or not and call the proper version.
I am not sure about the way I am detecting this though so any feedback will be much appreciated.
`bool is_signed = overload.back() == 'i';`
