### PR TITLE
Make the runtime work when OpenCL is loaded dynamically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,13 @@ endif()
 add_library(oclgrind-rt SHARED ${RUNTIME_SOURCES} ${DLL_EXPORTS})
 target_link_libraries(oclgrind-rt ${CMAKE_DL_LIBS} oclgrind)
 
+if (UNIX)
+  # Change the SONAME of the library so that it gets recognized by dlopen
+  set_target_properties(oclgrind-rt PROPERTIES
+                        NO_SONAME ON
+                        LINK_FLAGS "-Wl,-soname,libOpenCL.so")
+endif()
+
 add_executable(oclgrind-exe src/runtime/oclgrind.cpp)
 set_target_properties(oclgrind-exe PROPERTIES OUTPUT_NAME oclgrind)
 target_compile_definitions(oclgrind-exe PRIVATE


### PR DESCRIPTION
This makes Oclgrind's `LD_PRELOAD` mechanism work when OpenCL is loaded dynamically via `dlopen`. In particular, it makes Oclgrind usable when OpenCL is used through OpenCV and fixes #114.

It does so by setting the runtime library's `soname` to `libOpenCL.so`. Before loading a library `dlopen` will compare its name to the ones that are already loaded and reuse them if possible. See http://stackoverflow.com/a/37795834 for more information.