### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - osx
 
 sudo: required
-dist: trusty
+dist: xenial
 osx_image: xcode7.3
 
 language: cpp


### PR DESCRIPTION
Thank you for an awesome and helpful project!
(ubuntu 18.04) Bionic packages version 16.10 which is a little dated.
I hit a bug (my app erroneously used out-of-order queues when unsupported and oclgrind segfaulted)
So I tried to upgrade. (18.3 correctly returns an error in the above case)
I hit a snag upgrading without libreadline6.

I did a git clone of the repo and built from source and everything "just worked" on ubuntu 18.04.
My hope is that xenial is a little fresher and using the release tarball will work.

Update trusty -> xenial
Bionic (18.04) doesn't have a libreadline6 package so the prebuilt tar.gz doesn't run.

Thank you again!

