### PR TITLE
Fix memory leak in context properties

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -961,6 +961,10 @@ clReleaseContext
 
   if (--context->refCount == 0)
   {
+    if (context->properties)
+    {
+      free(context->properties);
+    }
     delete context->context;
     delete context;
   }


### PR DESCRIPTION
Memory may be allocated for context properties [here](https://github.com/jrprice/Oclgrind/blob/master/src/runtime/runtime.cpp#L874). However, this memory is never released when deleting a context. The proposed fix checks if this memory was allocated, and if so, frees it.

All runtime tests pass.