### PR TITLE
Add missing reference count initialization for sampler objects

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2077,6 +2077,7 @@ clCreateSampler
   sampler->addressMode = addressing_mode;
   sampler->filterMode = filter_mode;
   sampler->sampler = bitfield;
+  sampler->refCount = 1;
 
   SetError(context, CL_SUCCESS);
   return sampler;


### PR DESCRIPTION
Fixes two issues highlighted by Valgrind:

* "Conditional jump or move depends on uninitialised value(s)" on
  clReleaseSampler (runtime.cpp:2116)
* Memory leak when using samplers, since these were not properly
  released