### PR TITLE
Fix memory leaks when releasing commands

### DIFF
--- a/src/core/Queue.h
+++ b/src/core/Queue.h
@@ -35,6 +35,7 @@ namespace oclgrind
       {
         type = EMPTY;
       }
+      virtual ~Command() { }
     private:
       Event *event;
       friend class Queue;
@@ -102,7 +103,7 @@ namespace oclgrind
       size_t origin[3], region[3];
       size_t rowPitch, slicePitch;
       size_t pixelSize;
-      unsigned char color[16];
+      unsigned char *color;
       FillImageCommand(size_t b, const size_t o[3], const size_t r[3],
                        size_t rp, size_t sp,
                        size_t ps, const unsigned char *col)
@@ -114,7 +115,12 @@ namespace oclgrind
         rowPitch = rp;
         slicePitch = sp;
         pixelSize = ps;
-        memcpy(color, col, 16);
+        color = new unsigned char[ps];
+        memcpy(color, col, ps);
+      }
+      ~FillImageCommand()
+      {
+        delete[] color;
       }
     };
     struct KernelCommand : Command


### PR DESCRIPTION
Instances of derived command structs with destructors were not being freed since the Command base struct didn't have a virtual destructor.

Found this when adding a destructor to the FillImageCommand struct, and noticing that it was not being invoked.

I initially added this destructor due to an invalid read size valgrind warning in the following instruction:

```cpp
memcpy(color, col, 16);
```

Size of color object may not be 16 (it depends on pixel size), thus the warning. As such, the color object is now dynamically allocated depending on the pixel size, and destroyed in the respective destructor.