### PR TITLE
Fix memory leaks when passing images as kernel arguments

### DIFF
--- a/src/core/common.h
+++ b/src/core/common.h
@@ -147,12 +147,12 @@ namespace oclgrind
   typedef std::map<const llvm::Value*,TypedValue> TypedValueMap;
 
   // Image object
-  typedef struct
+  struct Image
   {
     size_t address;
     cl_image_format format;
     cl_image_desc desc;
-  } Image;
+  };
 
   // Check if an environment variable is set to 1
   bool checkEnv(const char *var);

--- a/src/runtime/icd.h
+++ b/src/runtime/icd.h
@@ -113,6 +113,8 @@
 #define clCreateEventFromGLsyncKHR _clCreateEventFromGLsyncKHR
 #endif // OCLGRIND_ICD
 
+#include "core/common.h"
+
 #include <list>
 #include <map>
 #include <stack>
@@ -209,6 +211,7 @@ struct _cl_kernel
   oclgrind::Kernel *kernel;
   cl_program program;
   std::map<cl_uint, cl_mem> memArgs;
+  std::stack<oclgrind::Image*> imageArgs;
   unsigned int refCount;
 };
 

--- a/src/runtime/icd.h
+++ b/src/runtime/icd.h
@@ -113,8 +113,6 @@
 #define clCreateEventFromGLsyncKHR _clCreateEventFromGLsyncKHR
 #endif // OCLGRIND_ICD
 
-#include "core/common.h"
-
 #include <list>
 #include <map>
 #include <stack>
@@ -140,6 +138,7 @@ namespace oclgrind
   class Program;
   class Queue;
   struct Event;
+  struct Image;
 }
 
 struct _cl_platform_id

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2882,6 +2882,15 @@ clReleaseKernel
 
   if (--kernel->refCount == 0)
   {
+
+    // Release memory allocated for image arguments
+    while (!kernel->imageArgs.empty())
+    {
+      oclgrind::Image* img = kernel->imageArgs.top();
+      kernel->imageArgs.pop();
+      delete img;
+    }
+
     delete kernel->kernel;
 
     clReleaseProgram(kernel->program);
@@ -2962,6 +2971,8 @@ clSetKernelArg
         image->format = ((cl_image*)mem)->format;
         image->desc = ((cl_image*)mem)->desc;
         *(oclgrind::Image**)value.data = image;
+        // Keep a record of the image struct for releasing it later
+        kernel->imageArgs.push(image);
       }
       else
       {


### PR DESCRIPTION
When passing an image as a kernel argument, memory is allocated for a `oclgrind::Image struct`. This memory was not being released.

The proposed fix keeps a record of these objects in the respective kernel instance (`_cl_kernel`), and releases them when the kernel instance is destroyed.