### PR TITLE
Fix uninitialised value Kernel::m_requiresUniformWorkGroups

### DIFF
--- a/src/core/Kernel.cpp
+++ b/src/core/Kernel.cpp
@@ -111,6 +111,7 @@ Kernel::Kernel(const Kernel& kernel)
   m_function = kernel.m_function;
   m_name = kernel.m_name;
   m_metadata = kernel.m_metadata;
+  m_requiresUniformWorkGroups = kernel.m_requiresUniformWorkGroups;
 
   for (auto itr = kernel.m_values.begin(); itr != kernel.m_values.end(); itr++)
   {


### PR DESCRIPTION
By fixing issue #169, part of the same problem moved from `Program` to `Kernel`, now occurring when creating a `Kernel` from another kernel with the `Kernel(const Kernel& kernel)` constructor.

The proposed fix simply adds the check for uniform work-groups to the `Kernel(const Kernel& kernel)` constructor. Since the same check is now made in both `Kernel` constructors, the associated code has been moved to a private method.

This is a pretty naive fix, so feel free to reject the PR or suggest a proper way to solve the issue.

Thanks