### PR TITLE
Add support for multiple queues

### DIFF
--- a/src/core/Queue.cpp
+++ b/src/core/Queue.cpp
@@ -193,7 +193,7 @@ bool Queue::isEmpty() const
   return m_queue.empty();
 }
 
-Queue::Command* Queue::update()
+Command* Queue::update()
 {
   if (m_queue.empty())
   {
@@ -228,42 +228,42 @@ Queue::Command* Queue::update()
   // Dispatch command
   switch (cmd->type)
   {
-  case COPY:
+  case Command::COPY:
     executeCopyBuffer((CopyCommand*)cmd);
     break;
-  case COPY_RECT:
+  case Command::COPY_RECT:
     executeCopyBufferRect((CopyRectCommand*)cmd);
     break;
-  case EMPTY:
+  case Command::EMPTY:
     break;
-  case FILL_BUFFER:
+  case Command::FILL_BUFFER:
     executeFillBuffer((FillBufferCommand*)cmd);
     break;
-  case FILL_IMAGE:
+  case Command::FILL_IMAGE:
     executeFillImage((FillImageCommand*)cmd);
     break;
-  case READ:
+  case Command::READ:
     executeReadBuffer((BufferCommand*)cmd);
     break;
-  case READ_RECT:
+  case Command::READ_RECT:
     executeReadBufferRect((BufferRectCommand*)cmd);
     break;
-  case KERNEL:
+  case Command::KERNEL:
     executeKernel((KernelCommand*)cmd);
     break;
-  case MAP:
+  case Command::MAP:
     executeMap((MapCommand*)cmd);
     break;
-  case NATIVE_KERNEL:
+  case Command::NATIVE_KERNEL:
     executeNativeKernel((NativeKernelCommand*)cmd);
     break;
-  case UNMAP:
+  case Command::UNMAP:
     executeUnmap((UnmapCommand*)cmd);
     break;
-  case WRITE:
+  case Command::WRITE:
     executeWriteBuffer((BufferCommand*)cmd);
     break;
-  case WRITE_RECT:
+  case Command::WRITE_RECT:
     executeWriteBufferRect((BufferRectCommand*)cmd);
     break;
   default:

--- a/src/core/Queue.cpp
+++ b/src/core/Queue.cpp
@@ -293,7 +293,7 @@ void Queue::execute(Command *command)
   m_queue.erase(it);
 }
 
-Command* Queue::update()
+Command* Queue::finish()
 {
   if (m_queue.empty())
   {

--- a/src/core/Queue.cpp
+++ b/src/core/Queue.cpp
@@ -218,12 +218,23 @@ void Queue::execute(Command *command)
     if (evt->state < 0)
     {
       command->event->state = evt->state;
+      m_queue.erase(it);
       return;
     }
     else if (evt->state != CL_COMPLETE)
     {
-      evt->queue->execute(evt->command);
-      command->execBefore.push_front(evt->command);
+      if (evt->command)
+      {
+        // If it's not a user event, execute the associated command
+        evt->queue->execute(evt->command);
+        command->execBefore.push_front(evt->command);
+      }
+      else
+      {
+        // If it's a user event then place it back at the of the wait list, and
+        // check it later
+        command->waitList.push_back(evt);
+      }
     }
   }
 

--- a/src/core/Queue.h
+++ b/src/core/Queue.h
@@ -13,11 +13,15 @@ namespace oclgrind
 {
   class Context;
   class Kernel;
+  class Queue;
+  struct Command;
 
   struct Event
   {
     int state;
     double queueTime, startTime, endTime;
+    Command *command;
+    Queue *queue;
     Event();
   };
 
@@ -29,6 +33,7 @@ namespace oclgrind
 
     CommandType type;
     std::list<Event*> waitList;
+    std::list<Command*> execBefore;
     Command()
     {
       type = EMPTY;
@@ -36,6 +41,7 @@ namespace oclgrind
     virtual ~Command() { }
   private:
     Event *event;
+    Command *previous;
     friend class Queue;
   };
   struct BufferCommand : Command
@@ -189,6 +195,7 @@ namespace oclgrind
     virtual ~Queue();
 
     Event* enqueue(Command *command);
+    void execute(Command *command);
 
     void executeCopyBuffer(CopyCommand *cmd);
     void executeCopyBufferRect(CopyRectCommand *cmd);
@@ -208,6 +215,6 @@ namespace oclgrind
 
   private:
     const Context *m_context;
-    std::queue<Command*> m_queue;
+    std::list<Command*> m_queue;
   };
 }

--- a/src/core/Queue.h
+++ b/src/core/Queue.h
@@ -21,169 +21,169 @@ namespace oclgrind
     Event();
   };
 
-  class Queue
+  struct Command
   {
-  public:
     enum CommandType {EMPTY, COPY, COPY_RECT, FILL_BUFFER, FILL_IMAGE, KERNEL,
                       MAP, NATIVE_KERNEL, READ, READ_RECT, UNMAP, WRITE,
                       WRITE_RECT};
-    struct Command
-    {
-      CommandType type;
-      std::list<Event*> waitList;
-      Command()
-      {
-        type = EMPTY;
-      }
-      virtual ~Command() { }
-    private:
-      Event *event;
-      friend class Queue;
-    };
-    struct BufferCommand : Command
-    {
-      unsigned char *ptr;
-      size_t address, size;
-      BufferCommand(CommandType t)
-      {
-        type = t;
-      }
-    };
-    struct BufferRectCommand : Command
-    {
-      unsigned char *ptr;
-      size_t address;
-      size_t region[3];
-      size_t host_offset[3];
-      size_t buffer_offset[3];
-      BufferRectCommand(CommandType t)
-      {
-        type = t;
-      }
-    };
-    struct CopyCommand : Command
-    {
-      size_t src, dst, size;
-      CopyCommand()
-      {
-        type = COPY;
-      }
-    };
-    struct CopyRectCommand : Command
-    {
-      size_t src, dst;
-      size_t region[3];
-      size_t src_offset[3];
-      size_t dst_offset[3];
-      CopyRectCommand()
-      {
-        type = COPY_RECT;
-      }
-    };
-    struct FillBufferCommand : Command
-    {
-      size_t address, size;
-      size_t pattern_size;
-      unsigned char *pattern;
-      FillBufferCommand(const unsigned char *p, size_t sz)
-      {
-        type = FILL_BUFFER;
-        pattern = new unsigned char[sz];
-        pattern_size = sz;
-        memcpy(pattern, p, sz);
-      }
-      ~FillBufferCommand()
-      {
-        delete[] pattern;
-      }
-    };
-    struct FillImageCommand : Command
-    {
-      size_t base;
-      size_t origin[3], region[3];
-      size_t rowPitch, slicePitch;
-      size_t pixelSize;
-      unsigned char *color;
-      FillImageCommand(size_t b, const size_t o[3], const size_t r[3],
-                       size_t rp, size_t sp,
-                       size_t ps, const unsigned char *col)
-      {
-        type = FILL_IMAGE;
-        base = b;
-        memcpy(origin, o, sizeof(size_t)*3);
-        memcpy(region, r, sizeof(size_t)*3);
-        rowPitch = rp;
-        slicePitch = sp;
-        pixelSize = ps;
-        color = new unsigned char[ps];
-        memcpy(color, col, ps);
-      }
-      ~FillImageCommand()
-      {
-        delete[] color;
-      }
-    };
-    struct KernelCommand : Command
-    {
-      Kernel *kernel;
-      unsigned int work_dim;
-      Size3 globalOffset;
-      Size3 globalSize;
-      Size3 localSize;
-      KernelCommand()
-      {
-        type = KERNEL;
-      }
-    };
-    struct NativeKernelCommand : Command
-    {
-      void (CL_CALLBACK *func)(void *);
-      void *args;
-      NativeKernelCommand(void (CL_CALLBACK *f)(void *),
-                          void *a, size_t sz)
-      {
-        type = NATIVE_KERNEL;
-        func = f;
-        if (a)
-        {
-          args = malloc(sz);
-          memcpy(args, a, sz);
-        }
-        else
-        {
-          args = NULL;
-        }
-      }
-      ~NativeKernelCommand()
-      {
-        if (args)
-        {
-          free(args);
-        }
-      }
-    };
-    struct MapCommand : Command
-    {
-      void *ptr;
-      size_t address;
-      size_t offset;
-      size_t size;
-      cl_map_flags flags;
-      MapCommand()
-      {
-        type = MAP;
-      }
-    };
-    struct UnmapCommand : Command
-    {
-      const void *ptr;
-      size_t address;
-      UnmapCommand()
-      {
-        type = UNMAP;
-      }
-    };
 
+    CommandType type;
+    std::list<Event*> waitList;
+    Command()
+    {
+      type = EMPTY;
+    }
+    virtual ~Command() { }
+  private:
+    Event *event;
+    friend class Queue;
+  };
+  struct BufferCommand : Command
+  {
+    unsigned char *ptr;
+    size_t address, size;
+    BufferCommand(CommandType t)
+    {
+      type = t;
+    }
+  };
+  struct BufferRectCommand : Command
+  {
+    unsigned char *ptr;
+    size_t address;
+    size_t region[3];
+    size_t host_offset[3];
+    size_t buffer_offset[3];
+    BufferRectCommand(CommandType t)
+    {
+      type = t;
+    }
+  };
+  struct CopyCommand : Command
+  {
+    size_t src, dst, size;
+    CopyCommand()
+    {
+      type = COPY;
+    }
+  };
+  struct CopyRectCommand : Command
+  {
+    size_t src, dst;
+    size_t region[3];
+    size_t src_offset[3];
+    size_t dst_offset[3];
+    CopyRectCommand()
+    {
+      type = COPY_RECT;
+    }
+  };
+  struct FillBufferCommand : Command
+  {
+    size_t address, size;
+    size_t pattern_size;
+    unsigned char *pattern;
+    FillBufferCommand(const unsigned char *p, size_t sz)
+    {
+      type = FILL_BUFFER;
+      pattern = new unsigned char[sz];
+      pattern_size = sz;
+      memcpy(pattern, p, sz);
+    }
+    ~FillBufferCommand()
+    {
+      delete[] pattern;
+    }
+  };
+  struct FillImageCommand : Command
+  {
+    size_t base;
+    size_t origin[3], region[3];
+    size_t rowPitch, slicePitch;
+    size_t pixelSize;
+    unsigned char *color;
+    FillImageCommand(size_t b, const size_t o[3], const size_t r[3],
+                     size_t rp, size_t sp,
+                     size_t ps, const unsigned char *col)
+    {
+      type = FILL_IMAGE;
+      base = b;
+      memcpy(origin, o, sizeof(size_t)*3);
+      memcpy(region, r, sizeof(size_t)*3);
+      rowPitch = rp;
+      slicePitch = sp;
+      pixelSize = ps;
+      color = new unsigned char[ps];
+      memcpy(color, col, ps);
+    }
+    ~FillImageCommand()
+    {
+      delete[] color;
+    }
+  };
+  struct KernelCommand : Command
+  {
+    Kernel *kernel;
+    unsigned int work_dim;
+    Size3 globalOffset;
+    Size3 globalSize;
+    Size3 localSize;
+    KernelCommand()
+    {
+      type = KERNEL;
+    }
+  };
+  struct NativeKernelCommand : Command
+  {
+    void (CL_CALLBACK *func)(void *);
+    void *args;
+    NativeKernelCommand(void (CL_CALLBACK *f)(void *),
+                        void *a, size_t sz)
+    {
+      type = NATIVE_KERNEL;
+      func = f;
+      if (a)
+      {
+        args = malloc(sz);
+        memcpy(args, a, sz);
+      }
+      else
+      {
+        args = NULL;
+      }
+    }
+    ~NativeKernelCommand()
+    {
+      if (args)
+      {
+        free(args);
+      }
+    }
+  };
+  struct MapCommand : Command
+  {
+    void *ptr;
+    size_t address;
+    size_t offset;
+    size_t size;
+    cl_map_flags flags;
+    MapCommand()
+    {
+      type = MAP;
+    }
+  };
+  struct UnmapCommand : Command
+  {
+    const void *ptr;
+    size_t address;
+    UnmapCommand()
+    {
+      type = UNMAP;
+    }
+  };
+
+  class Queue
+  {
   public:
     Queue(const Context *context);
     virtual ~Queue();

--- a/src/core/Queue.h
+++ b/src/core/Queue.h
@@ -210,7 +210,7 @@ namespace oclgrind
     void executeWriteBufferRect(BufferRectCommand *cmd);
 
     bool isEmpty() const;
-    Command* update();
+    Command* finish();
 
   private:
     const Context *m_context;

--- a/src/core/Queue.h
+++ b/src/core/Queue.h
@@ -41,7 +41,6 @@ namespace oclgrind
     virtual ~Command() { }
   private:
     Event *event;
-    Command *previous;
     friend class Queue;
   };
   struct BufferCommand : Command

--- a/src/runtime/async_queue.cpp
+++ b/src/runtime/async_queue.cpp
@@ -20,14 +20,14 @@ using namespace oclgrind;
 using namespace std;
 
 // Maps to keep track of retained objects
-static map< Queue::Command*, list<cl_mem> > memObjectMap;
-static map< Queue::Command*, cl_kernel > kernelMap;
-static map< Queue::Command*, cl_event > eventMap;
-static map< Queue::Command*, list<cl_event> > waitListMap;
+static map< Command*, list<cl_mem> > memObjectMap;
+static map< Command*, cl_kernel > kernelMap;
+static map< Command*, cl_event > eventMap;
+static map< Command*, list<cl_event> > waitListMap;
 
 void asyncEnqueue(cl_command_queue queue,
                   cl_command_type type,
-                  Queue::Command *cmd,
+                  Command *cmd,
                   cl_uint numEvents,
                   const cl_event *waitList,
                   cl_event *eventOut)
@@ -63,14 +63,14 @@ void asyncEnqueue(cl_command_queue queue,
   }
 }
 
-void asyncQueueRetain(Queue::Command *cmd, cl_mem mem)
+void asyncQueueRetain(Command *cmd, cl_mem mem)
 {
   // Retain object and add to map
   clRetainMemObject(mem);
   memObjectMap[cmd].push_back(mem);
 }
 
-void asyncQueueRetain(Queue::Command *cmd, cl_kernel kernel)
+void asyncQueueRetain(Command *cmd, cl_kernel kernel)
 {
   assert(kernelMap.find(cmd) == kernelMap.end());
 
@@ -86,7 +86,7 @@ void asyncQueueRetain(Queue::Command *cmd, cl_kernel kernel)
   }
 }
 
-void asyncQueueRelease(Queue::Command *cmd)
+void asyncQueueRelease(Command *cmd)
 {
   // Release memory objects
   if (memObjectMap.find(cmd) != memObjectMap.end())
@@ -101,12 +101,12 @@ void asyncQueueRelease(Queue::Command *cmd)
   }
 
   // Release kernel
-  if (cmd->type == Queue::KERNEL)
+  if (cmd->type == Command::KERNEL)
   {
     assert(kernelMap.find(cmd) != kernelMap.end());
     clReleaseKernel(kernelMap[cmd]);
     kernelMap.erase(cmd);
-    delete ((Queue::KernelCommand*)cmd)->kernel;
+    delete ((KernelCommand*)cmd)->kernel;
   }
 
   // Remove event from map

--- a/src/runtime/async_queue.h
+++ b/src/runtime/async_queue.h
@@ -12,10 +12,10 @@
 
 extern void asyncEnqueue(cl_command_queue queue,
                          cl_command_type type,
-                         oclgrind::Queue::Command *cmd,
+                         oclgrind::Command *cmd,
                          cl_uint numEvents,
                          const cl_event *waitList,
                          cl_event *eventOut);
-extern void asyncQueueRetain(oclgrind::Queue::Command *cmd, cl_mem mem);
-extern void asyncQueueRetain(oclgrind::Queue::Command *cmd, cl_kernel);
-extern void asyncQueueRelease(oclgrind::Queue::Command *cmd);
+extern void asyncQueueRetain(oclgrind::Command *cmd, cl_mem mem);
+extern void asyncQueueRetain(oclgrind::Command *cmd, cl_kernel);
+extern void asyncQueueRelease(oclgrind::Command *cmd);

--- a/src/runtime/icd.h
+++ b/src/runtime/icd.h
@@ -137,6 +137,7 @@ namespace oclgrind
   class Kernel;
   class Program;
   class Queue;
+  struct Command;
   struct Event;
   struct Image;
 }

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -3627,8 +3627,8 @@ clFinish
     ReturnErrorArg(NULL, CL_INVALID_COMMAND_QUEUE, command_queue);
   }
 
-  // TODO: Move this update to async thread?
-  oclgrind::Command *cmd = command_queue->queue->update();
+  // TODO: Move this finish to async thread?
+  oclgrind::Command *cmd = command_queue->queue->finish();
   releaseCommand(cmd);
 
   return CL_SUCCESS;

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -3276,7 +3276,7 @@ clWaitForEvents
       // If it's not a user event, update the queue
       if (event_list[i]->queue)
       {
-        oclgrind::Queue::Command *cmd = event_list[i]->queue->queue->update();
+        oclgrind::Command *cmd = event_list[i]->queue->queue->update();
         if (cmd)
         {
           asyncQueueRelease(cmd);
@@ -3613,7 +3613,7 @@ clFinish
   while (!command_queue->queue->isEmpty())
   {
     // TODO: Move this update to async thread?
-    oclgrind::Queue::Command *cmd = command_queue->queue->update();
+    oclgrind::Command *cmd = command_queue->queue->update();
     if (cmd)
     {
       asyncQueueRelease(cmd);
@@ -3664,8 +3664,8 @@ clEnqueueReadBuffer
   }
 
   // Enqueue command
-  oclgrind::Queue::BufferCommand *cmd =
-    new oclgrind::Queue::BufferCommand(oclgrind::Queue::READ);
+  oclgrind::BufferCommand *cmd =
+    new oclgrind::BufferCommand(oclgrind::Command::READ);
   cmd->ptr = (unsigned char*)ptr;
   cmd->address = buffer->address + offset;
   cmd->size = cb;
@@ -3760,8 +3760,8 @@ clEnqueueReadBufferRect
   }
 
   // Enqueue command
-  oclgrind::Queue::BufferRectCommand *cmd =
-    new oclgrind::Queue::BufferRectCommand(oclgrind::Queue::READ_RECT);
+  oclgrind::BufferRectCommand *cmd =
+    new oclgrind::BufferRectCommand(oclgrind::Command::READ_RECT);
   cmd->ptr = (unsigned char*)ptr;
   cmd->address = buffer->address;
   cmd->buffer_offset[0] = buffer_offset;
@@ -3823,8 +3823,8 @@ clEnqueueWriteBuffer
   }
 
   // Enqueue command
-  oclgrind::Queue::BufferCommand *cmd =
-    new oclgrind::Queue::BufferCommand(oclgrind::Queue::WRITE);
+  oclgrind::BufferCommand *cmd =
+    new oclgrind::BufferCommand(oclgrind::Command::WRITE);
   cmd->ptr = (unsigned char*)ptr;
   cmd->address = buffer->address + offset;
   cmd->size = cb;
@@ -3919,8 +3919,8 @@ clEnqueueWriteBufferRect
   }
 
   // Enqueue command
-  oclgrind::Queue::BufferRectCommand *cmd =
-    new oclgrind::Queue::BufferRectCommand(oclgrind::Queue::WRITE_RECT);
+  oclgrind::BufferRectCommand *cmd =
+    new oclgrind::BufferRectCommand(oclgrind::Command::WRITE_RECT);
   cmd->ptr = (unsigned char*)ptr;
   cmd->address = buffer->address;
   cmd->buffer_offset[0] = buffer_offset;
@@ -4005,7 +4005,7 @@ clEnqueueCopyBuffer
   }
 
   // Enqueue command
-  oclgrind::Queue::CopyCommand *cmd = new oclgrind::Queue::CopyCommand();
+  oclgrind::CopyCommand *cmd = new oclgrind::CopyCommand();
   cmd->dst = dst_buffer->address + dst_offset;
   cmd->src = src_buffer->address + src_offset;
   cmd->size = cb;
@@ -4104,7 +4104,7 @@ clEnqueueCopyBufferRect
   }
 
   // Enqueue command
-  oclgrind::Queue::CopyRectCommand *cmd = new oclgrind::Queue::CopyRectCommand();
+  oclgrind::CopyRectCommand *cmd = new oclgrind::CopyRectCommand();
   cmd->src = src_buffer->address;
   cmd->dst = dst_buffer->address;
   cmd->src_offset[0] = src_offset;
@@ -4173,9 +4173,9 @@ clEnqueueFillBuffer
   }
 
   // Enqueue command
-  oclgrind::Queue::FillBufferCommand *cmd =
-    new oclgrind::Queue::FillBufferCommand((const unsigned char*)pattern,
-                                          pattern_size);
+  oclgrind::FillBufferCommand *cmd =
+    new oclgrind::FillBufferCommand((const unsigned char*)pattern,
+                                     pattern_size);
   cmd->address = buffer->address + offset;
   cmd->size = cb;
   asyncQueueRetain(cmd, buffer);
@@ -4345,10 +4345,10 @@ clEnqueueFillImage
   }
 
   // Enqueue command
-  oclgrind::Queue::FillImageCommand *cmd =
-    new oclgrind::Queue::FillImageCommand(image->address, origin, region,
-                                         row_pitch, slice_pitch,
-                                         pixelSize, color);
+  oclgrind::FillImageCommand *cmd =
+    new oclgrind::FillImageCommand(image->address, origin, region,
+                                   row_pitch, slice_pitch,
+                                   pixelSize, color);
   asyncQueueRetain(cmd, image);
   asyncEnqueue(command_queue, CL_COMMAND_FILL_IMAGE, cmd,
                num_events_in_wait_list, event_wait_list, event);
@@ -4701,7 +4701,7 @@ clEnqueueMapBuffer
   }
 
   // Enqueue command
-  oclgrind::Queue::MapCommand *cmd = new oclgrind::Queue::MapCommand();
+  oclgrind::MapCommand *cmd = new oclgrind::MapCommand();
   cmd->address = buffer->address;
   cmd->offset  = offset;
   cmd->size    = cb;
@@ -4834,7 +4834,7 @@ clEnqueueMapImage
   }
 
   // Enqueue command
-  oclgrind::Queue::MapCommand *cmd = new oclgrind::Queue::MapCommand();
+  oclgrind::MapCommand *cmd = new oclgrind::MapCommand();
   cmd->address = image->address;
   cmd->offset  = offset;
   cmd->size    = size;
@@ -4878,7 +4878,7 @@ clEnqueueUnmapMemObject
   }
 
   // Enqueue command
-  oclgrind::Queue::UnmapCommand *cmd = new oclgrind::Queue::UnmapCommand();
+  oclgrind::UnmapCommand *cmd = new oclgrind::UnmapCommand();
   cmd->address = memobj->address;
   cmd->ptr     = mapped_ptr;
   asyncQueueRetain(cmd, memobj);
@@ -4907,7 +4907,7 @@ clEnqueueMigrateMemObjects
   }
 
   // Enqueue command
-  oclgrind::Queue::Command *cmd = new oclgrind::Queue::Command();
+  oclgrind::Command *cmd = new oclgrind::Command();
   asyncEnqueue(command_queue, CL_COMMAND_MIGRATE_MEM_OBJECTS, cmd,
                num_events_in_wait_list, event_wait_list, event);
 
@@ -5023,7 +5023,7 @@ clEnqueueNDRangeKernel
   }
 
   // Set-up offsets and sizes
-  oclgrind::Queue::KernelCommand *cmd = new oclgrind::Queue::KernelCommand();
+  oclgrind::KernelCommand *cmd = new oclgrind::KernelCommand();
   cmd->kernel = new oclgrind::Kernel(*kernel->kernel);
   cmd->work_dim = work_dim;
   cmd->globalSize   = oclgrind::Size3(1, 1, 1);
@@ -5130,8 +5130,8 @@ clEnqueueNativeKernel
   }
 
   // Create command
-  oclgrind::Queue::NativeKernelCommand *cmd =
-    new oclgrind::Queue::NativeKernelCommand(user_func, args, cb_args);
+  oclgrind::NativeKernelCommand *cmd =
+    new oclgrind::NativeKernelCommand(user_func, args, cb_args);
 
   // Retain memory objects
   for (unsigned i = 0; i < num_mem_objects; i++)
@@ -5172,7 +5172,7 @@ clEnqueueMarkerWithWaitList
   }
 
   // Enqueue command
-  oclgrind::Queue::Command *cmd = new oclgrind::Queue::Command();
+  oclgrind::Command *cmd = new oclgrind::Command();
   asyncEnqueue(command_queue, CL_COMMAND_MARKER, cmd,
                num_events_in_wait_list, event_wait_list, event);
 
@@ -5195,7 +5195,7 @@ clEnqueueBarrierWithWaitList
   }
 
   // Enqueue command
-  oclgrind::Queue::Command *cmd = new oclgrind::Queue::Command();
+  oclgrind::Command *cmd = new oclgrind::Command();
   asyncEnqueue(command_queue, CL_COMMAND_BARRIER, cmd,
                num_events_in_wait_list, event_wait_list, event);
 
@@ -5237,7 +5237,7 @@ clEnqueueWaitForEvents
   }
 
   // Enqueue command
-  oclgrind::Queue::Command *cmd = new oclgrind::Queue::Command();
+  oclgrind::Command *cmd = new oclgrind::Command();
   asyncEnqueue(command_queue, CL_COMMAND_BARRIER, cmd,
                num_events, event_list, NULL);
 

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -3419,6 +3419,8 @@ clCreateUserEvent
   event->type = CL_COMMAND_USER;
   event->event = new oclgrind::Event();
   event->event->state = CL_SUBMITTED;
+  event->event->command = NULL;
+  event->event->queue = NULL;
   event->refCount = 1;
 
   SetError(context, CL_SUCCESS);

--- a/tests/common/common.c
+++ b/tests/common/common.c
@@ -12,6 +12,19 @@ void checkError(cl_int err, const char *operation)
   }
 }
 
+// Check platform is Oclgrind
+void checkOclgrindPlatform(cl_platform_id platform)
+{
+  char name[256];
+  cl_int err = clGetPlatformInfo(platform, CL_PLATFORM_NAME, 256, name, NULL);
+  checkError(err, "getting platform name");
+  if (strcmp(name, "Oclgrind"))
+  {
+    fprintf(stderr, "Unable to find Oclgrind platform\n");
+    exit(1);
+  }
+}
+
 Context createContext(const char *source, const char *options)
 {
   Context cl;
@@ -20,15 +33,7 @@ Context createContext(const char *source, const char *options)
   err = clGetPlatformIDs(1, &cl.platform, NULL);
   checkError(err, "getting platform");
 
-  // Check platform is Oclgrind
-  char name[256];
-  err = clGetPlatformInfo(cl.platform, CL_PLATFORM_NAME, 256, name, NULL);
-  checkError(err, "getting platform name");
-  if (strcmp(name, "Oclgrind"))
-  {
-    fprintf(stderr, "Unable to find Oclgrind platform\n");
-    exit(1);
-  }
+  checkOclgrindPlatform(cl.platform);
 
   err = clGetDeviceIDs(cl.platform, CL_DEVICE_TYPE_ALL, 1, &cl.device, NULL);
   checkError(err, "getting device");

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -10,6 +10,7 @@ typedef struct
 } Context;
 
 void checkError(cl_int err, const char *operation);
+void checkOclgrindPlatform(cl_platform_id platform);
 
 Context createContext(const char *source, const char *options);
 void    releaseContext(Context cl);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -14,6 +14,7 @@ foreach(test
   build_program
   kernel_scope_local_mem_usage
   map_buffer
+  multqueues
   sampler)
 
   add_executable(${test} ${test}.c ${COMMON_SOURCES})

--- a/tests/runtime/multqueues.c
+++ b/tests/runtime/multqueues.c
@@ -1,0 +1,82 @@
+#include "common.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+
+  cl_platform_id platf;
+  cl_device_id dev;
+  cl_int err;
+  cl_float buf_host1[] = { 1.2, 3.2, -4.9, 4.6, 9.0, -5.1, -9.7, 7.8 };
+  cl_float buf_host2[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+  cl_mem buf_dev = NULL;
+  cl_command_queue cq1 = NULL, cq2 = NULL;
+  cl_event evt1 = NULL, evt2 = NULL;
+  cl_context ctx = NULL;
+  cl_uint i;
+
+  // Get platform
+  err = clGetPlatformIDs(1, &platf, NULL);
+  checkError(err, "getting platform");
+
+  // Check its Oclgrind
+  checkOclgrindPlatform(platf);
+
+  // Get first device
+  err = clGetDeviceIDs(platf, CL_DEVICE_TYPE_ALL, 1, &dev, NULL);
+  checkError(err, "getting device");
+
+  // Create context
+  ctx = clCreateContext(NULL, 1, &dev, NULL, NULL, &err);
+  checkError(err, "creating context");
+
+  // Create first command queue
+  cq1 = clCreateCommandQueue(ctx, dev, 0, &err);
+  checkError(err, "creating first command queue");
+
+  // Create second command queue
+  cq2 = clCreateCommandQueue(ctx, dev, 0, &err);
+  checkError(err, "creating second command queue");
+
+  // Create a device buffer
+  buf_dev = clCreateBuffer(ctx, CL_MEM_READ_WRITE, 8 * sizeof(cl_float),
+                           NULL, &err);
+  checkError(err, "creating buffer");
+
+  // Write something to device buffer using command queue 1, get an event
+  err = clEnqueueWriteBuffer(cq1, buf_dev, CL_FALSE, 0,
+                             8 * sizeof(cl_float), buf_host1, 0, NULL, &evt1);
+  checkError(err, "writing to buffer");
+
+  // Read something from buffer using command queue 2, make it depend on
+  // previous event
+  err = clEnqueueReadBuffer(cq2, buf_dev, CL_FALSE, 0,
+                            8 * sizeof(cl_float), buf_host2, 1, &evt1, &evt2);
+  checkError(err, "reading from buffer");
+
+  // Wait on host thread for read event
+  clWaitForEvents(1, &evt2);
+
+  // Free stuff
+  clReleaseEvent(evt2);
+  clReleaseEvent(evt1);
+  clReleaseMemObject(buf_dev);
+  clReleaseCommandQueue(cq2);
+  clReleaseCommandQueue(cq1);
+  clReleaseContext(ctx);
+
+  // Check results
+  for (i = 0; i < 8; i++)
+  {
+    if (buf_host1[i] != buf_host2[i])
+    {
+      fprintf(stderr, "Incorrect results\n");
+      exit(1);
+    }
+  }
+
+  printf("OK\n");
+  return 0;
+}

--- a/tests/runtime/multqueues.ref
+++ b/tests/runtime/multqueues.ref
@@ -1,0 +1,1 @@
+EXACT OK


### PR DESCRIPTION
This proposal adds support for multiple queues, fixing issue #93. This required the following changes:

* The `Command` structs were moved out of the `Queue` class, although I've kept them in the same file.
* Added a `Queue::execute()` method, which executes a given command **in its queue**, but only after it recursively executes the commands associated with the events in its wait list  (**in their own queues**). If the queue is in-order, the event associated with the previous command in the queue is added to the wait list as an additional dependency. For now this is assumed to be true, but now it's very simple to implement out of order queues (I have actually [done this already](https://github.com/fakenmc/Oclgrind/tree/ooo_queues), and will submit the patch if this pull request is accepted, since it directly depends on it).
* The `Queue::update()` method now simply executes the last enqueued command using `Queue::execute()`, which recursively executes the associated graph of dependencies.
* The runtime function `clWaitForEvents()` calls `Queue::execute()` for each of the commands associated with the given events.
* The runtime function `clFinish()` simply calls `Queue::update()`.
* Command objects are still released in the runtime, as previously. However, this is now more complicated since the command object returned to the runtime is connected to a graph of other commands (i.e. its dependencies, in the `execBefore` list). As such, I've added the `releaseCommand()` helper function to the runtime, which recursively releases the graph of commands.
* I've also added a test case for testing the use of different queues.
* All your tests pass, as well as mine (cf4ocl), with no memory leaks.

Let me know if this is OK for you or if any changes are necessary.
