### PR TITLE
Add check for invalid region in clEnqueueCopyBufferRect

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -4048,6 +4048,10 @@ clEnqueueCopyBufferRect
   {
     ReturnErrorArg(command_queue->context, CL_INVALID_MEM_OBJECT, dst_buffer);
   }
+  if (!region || region[0] == 0 || region[1] == 0 || region[2] == 0)
+  {
+    ReturnErrorArg(command_queue->context, CL_INVALID_VALUE, region);
+  }
 
   // Compute pitches if necessary
   if (src_row_pitch == 0)


### PR DESCRIPTION
According to the OpenCL reference, the `clEnqueueCopyBufferRect()` function should return `CL_INVALID_VALUE` "if any region array element is 0." There's also check for a `NULL` region, although this is not explicit in the documentation.