### PR TITLE
Add check for invalid mapped pointer when unmapping memory objects

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -4868,6 +4868,10 @@ clEnqueueUnmapMemObject
   {
     ReturnErrorArg(command_queue->context, CL_INVALID_MEM_OBJECT, memobj);
   }
+  if (!mapped_ptr)
+  {
+    ReturnErrorArg(command_queue->context, CL_INVALID_VALUE, mapped_ptr);
+  }
 
   // Enqueue command
   oclgrind::Queue::UnmapCommand *cmd = new oclgrind::Queue::UnmapCommand();


### PR DESCRIPTION
In `clEnqueueUnmapMemObject()` documentation: "`CL_INVALID_VALUE` if `mapped_ptr` is not a valid pointer returned by `clEnqueueMapBuffer` or `clEnqueueMapImage` for `memobj`."