### PR TITLE
Fix shuffle and shuffle2 mask roll-over

### DIFF
--- a/src/core/WorkItemBuiltins.cpp
+++ b/src/core/WorkItemBuiltins.cpp
@@ -2596,7 +2596,7 @@ namespace oclgrind
     {
       for (unsigned i = 0; i < result.num; i++)
       {
-        result.setUInt(UARGV(0, UARGV(1, i)), i);
+        result.setUInt(UARGV(0, UARGV(1, i) % result.num), i);
       }
     }
 
@@ -2611,7 +2611,7 @@ namespace oclgrind
         }
 
         uint64_t src = 0;
-        uint64_t index = UARGV(2, i);
+        uint64_t index = UARGV(2, i) % (2 * m);
         if (index >= m)
         {
           index -= m;

--- a/src/plugins/Uninitialized.cpp
+++ b/src/plugins/Uninitialized.cpp
@@ -523,7 +523,7 @@ bool Uninitialized::handleBuiltinFunction(const WorkItem *workItem, string name,
             }
             else
             {
-                size_t srcOffset = mask.getUInt(i) * shadow.size;
+                size_t srcOffset = (mask.getUInt(i) % shadow.size) * shadow.size;
                 memcpy(newShadow.data + i*newShadow.size, shadow.data + srcOffset, newShadow.size);
             }
         }
@@ -549,7 +549,7 @@ bool Uninitialized::handleBuiltinFunction(const WorkItem *workItem, string name,
             }
 
             uint64_t src = 0;
-            uint64_t index = mask.getUInt(i);
+            uint64_t index = mask.getUInt(i) % (2 * m);
 
             if(index >= m)
             {


### PR DESCRIPTION
Implement roll-over for the `mask` parameter to the `shuffle` and `shuffle2`
functions as defined in the OpenCL spec to prevent out-of-bounds accesses.

The OpenCL spec ([here](https://www.khronos.org/registry/OpenCL/sdk/1.1/docs/man/xhtml/shuffle.html) allows `mask` values to be larger than the size of the (combined) source vector(s), as only the required number of least significant bits are taken into account.

Courtesy of Codeplay Software.