### PR TITLE
Add fneg Instruction

### DIFF
--- a/src/core/WorkItem.cpp
+++ b/src/core/WorkItem.cpp
@@ -174,6 +174,11 @@ void WorkItem::dispatch(const llvm::Instruction *instruction,
   case llvm::Instruction::FMul:
     fmul(instruction, result);
     break;
+#if LLVM_VERSION >= 80
+  case llvm::Instruction::FNeg:
+    fneg(instruction, result);
+    break;
+#endif
   case llvm::Instruction::FPExt:
     fpext(instruction, result);
     break;
@@ -1053,6 +1058,17 @@ INSTRUCTION(fmul)
     result.setFloat(opA.getFloat(i) * opB.getFloat(i), i);
   }
 }
+
+#if LLVM_VERSION >= 80
+INSTRUCTION(fneg)
+{
+  TypedValue op = getOperand(instruction->getOperand(0));
+  for (unsigned i = 0; i < result.num; i++)
+  {
+    result.setFloat(-op.getFloat(i), i);
+  }
+}
+#endif
 
 INSTRUCTION(fpext)
 {

--- a/src/core/WorkItem.h
+++ b/src/core/WorkItem.h
@@ -137,6 +137,9 @@ namespace oclgrind
     INSTRUCTION(fcmp);
     INSTRUCTION(fdiv);
     INSTRUCTION(fmul);
+#if LLVM_VERSION >= 80
+    INSTRUCTION(fneg);
+#endif
     INSTRUCTION(fpext);
     INSTRUCTION(fptosi);
     INSTRUCTION(fptoui);


### PR DESCRIPTION
The fneg instruction seems to have been added to LLVM 8 with [this commit](https://github.com/llvm/llvm-project/commit/cbde0d9c7be1991751dc3eb5928294d2e00ef26a). 