### PR TITLE
Add FNeg instruction to Uninitialized

### DIFF
--- a/src/plugins/Uninitialized.cpp
+++ b/src/plugins/Uninitialized.cpp
@@ -6,6 +6,7 @@
 // license terms please see the LICENSE file distributed with this
 // source code.
 
+#include "config.h"
 #include "core/common.h"
 
 #include "core/Context.h"

--- a/src/plugins/Uninitialized.cpp
+++ b/src/plugins/Uninitialized.cpp
@@ -1274,6 +1274,13 @@ void Uninitialized::instructionExecuted(const WorkItem *workItem,
             VectorOr(workItem, instruction);
             break;
         }
+#if LLVM_VERSION >= 80
+        case llvm::Instruction::FNeg:
+        {
+            VectorOr(workItem, instruction);
+            break;
+        }
+#endif
         case llvm::Instruction::FPExt:
         {
             SimpleOr(workItem, instruction);


### PR DESCRIPTION
It seems that FNeg support was added to core in 5bcf3f1853c666ad5361604a75bb5d0449276193, but it is missing in Uninitialized.  Which in my case leads to such errors:
```
OCLGRIND FATAL ERROR (/home/vsevak/oclgrind/src/plugins/Uninitialized.cpp:1725)
Unsupported instruction: fneg
	Kernel: k_tersoff_zbl_three_end
	Entity: Global(1728,0,0) Local(0,0,0) Group(27,0,0)
	  %fneg = fneg float %122, !dbg !279
	At line 1951 (column 19) of input.cl:
	  mdelr1[0] = -delr1[0];
```
The proposed patch is trivial and looks like solving the error (tests 98 out of 98), but since it is the only UnaryOperator there I ask you to review the changes.