### PR TITLE
Add support for LLVM 'freeze' instruction: treat as no-op.

### DIFF
--- a/src/core/WorkItem.cpp
+++ b/src/core/WorkItem.cpp
@@ -281,6 +281,9 @@ void WorkItem::dispatch(const llvm::Instruction *instruction,
   case llvm::Instruction::ZExt:
     zext(instruction, result);
     break;
+  case llvm::Instruction::Freeze:
+    freeze(instruction, result);
+    break;
   default:
     FATAL_ERROR("Unsupported instruction: %s", instruction->getOpcodeName());
   }
@@ -1578,6 +1581,11 @@ INSTRUCTION(zext)
   {
     result.setUInt(operand.getUInt(i), i);
   }
+}
+
+INSTRUCTION(freeze) {
+  TypedValue operand = getOperand(instruction->getOperand(0));
+  memcpy(result.data, operand.data, result.size * result.num);
 }
 
 #undef INSTRUCTION

--- a/src/core/WorkItem.h
+++ b/src/core/WorkItem.h
@@ -170,6 +170,7 @@ namespace oclgrind
     INSTRUCTION(uitofp);
     INSTRUCTION(urem);
     INSTRUCTION(zext);
+    INSTRUCTION(freeze);
 #undef INSTRUCTION
 
   private:


### PR DESCRIPTION
In case of LLVM instruction `freeze`, just copy value as a no-op, as _"All uses of a 'freeze' instruction are guaranteed to always observe the same value."_
[https://reviews.llvm.org/D29121](url)
[https://llvm.org/docs/LangRef.html#freeze-instruction](url)