### PR TITLE
Support LLVM 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-20.04, macos-11.0]
         compiler: [gcc, clang]
         build_type: [Release, Debug]
-        llvm: [11, 12, 13]
+        llvm: [11, 12, 13, 14]
         exclude:
           - os: ubuntu-20.04
             llvm: 11
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         platform: [Win32, x64]
-        llvm: [11, 12, 13]
+        llvm: [11, 12, 13, 14]
 
     steps:
       - uses: actions/checkout@v2
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build]
     env:
-      LLVM_VERSION: 13
+      LLVM_VERSION: 14
       cts_hash: 3dab3df48d7dbc22accf6c37c59e54e35a35de7f
 
     steps:
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build-cts]
     env:
-      LLVM_VERSION: 13
+      LLVM_VERSION: 14
       cts_hash: 3dab3df48d7dbc22accf6c37c59e54e35a35de7f
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           - os: ubuntu-20.04
             llvm: 11
           - os: macos-11.0
+            llvm: 13
+          - os: macos-11.0
             compiler: gcc
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build]
     env:
-      LLVM_VERSION: 14
       cts_hash: 3dab3df48d7dbc22accf6c37c59e54e35a35de7f
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -248,7 +246,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build-cts]
     env:
-      LLVM_VERSION: 14
       cts_hash: 3dab3df48d7dbc22accf6c37c59e54e35a35de7f
     strategy:
       fail-fast: false
@@ -288,7 +285,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: bash .github/workflows/install-deps.sh
+        run: >
+          LLVM_VERSION=${{ env.RELEASE_LLVM }} \
+            bash .github/workflows/install-deps.sh
       - name: Download Oclgrind
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/install-deps.sh
+++ b/.github/workflows/install-deps.sh
@@ -47,13 +47,19 @@ elif [[ "`uname`" == "MINGW64"* ]]; then
         curl -OL "$URL/$ARCHIVE"
         tar xf "$ARCHIVE" --strip-components 1 -C llvm-${LLVM_VERSION}/tools/clang
 
+        if [ ${LLVM_VERSION} == 14 ]; then
+            mkdir -p cmake
+            mv "llvm-${LLVM_VERSION}/Modules" cmake
+        fi
+
         # Build LLVM + Clang
         mkdir -p llvm-${LLVM_VERSION}/build
         cd llvm-${LLVM_VERSION}/build
         cmake .. \
-        -G "Visual Studio 16 2019" -A ${BUILD_PLATFORM} \
-        -DCMAKE_INSTALL_PREFIX=$PWD/../install \
-        -DLLVM_TARGETS_TO_BUILD=host
+            -G "Visual Studio 16 2019" -A ${BUILD_PLATFORM} \
+            -DCMAKE_INSTALL_PREFIX=$PWD/../install \
+            -DLLVM_TARGETS_TO_BUILD=host \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF
         cmake --build . --config Release --target ALL_BUILD
         cmake --build . --config Release --target INSTALL
     fi

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 For more information, please visit the Oclgrind Wiki:
 https://github.com/jrprice/Oclgrind/wiki
 
+Oclgrind Next
+=============
+- Added support for LLVM 14
 
 Oclgrind 21.10
 ==============

--- a/src/core/WorkItemBuiltins.cpp
+++ b/src/core/WorkItemBuiltins.cpp
@@ -1229,7 +1229,7 @@ class WorkItemBuiltins
     int coordIndex = 1;
 
     // Check for sampler version
-    if (callInst->getNumArgOperands() > 2)
+    if (callInst->arg_size() > 2)
     {
       sampler = ((llvm::ConstantInt*)PARG(1))->getZExtValue();
       coordIndex = 2;
@@ -1346,7 +1346,7 @@ class WorkItemBuiltins
     int coordIndex = 1;
 
     // Check for sampler version
-    if (callInst->getNumArgOperands() > 2)
+    if (callInst->arg_size() > 2)
     {
       sampler = ((llvm::ConstantInt*)PARG(1))->getZExtValue();
       coordIndex = 2;
@@ -1419,7 +1419,7 @@ class WorkItemBuiltins
     int coordIndex = 1;
 
     // Check for sampler version
-    if (callInst->getNumArgOperands() > 2)
+    if (callInst->arg_size() > 2)
     {
       sampler = ((llvm::ConstantInt*)PARG(1))->getZExtValue();
       coordIndex = 2;

--- a/src/plugins/Uninitialized.cpp
+++ b/src/plugins/Uninitialized.cpp
@@ -2070,7 +2070,7 @@ void Uninitialized::SimpleOrAtomic(const WorkItem* workItem,
     newShadow = ShadowContext::getPoisonedValue(4);
   }
 
-  if (CI->getNumArgOperands() > 1)
+  if (CI->arg_size() > 1)
   {
     TypedValue argShadow =
       shadowContext.getValue(workItem, CI->getArgOperand(1));


### PR DESCRIPTION
This makes `Oclgrind` compile on LLVM 14. I ran it through the `pyopencl` test suite and it didn't segfault, so it should be reasonably ok.

Not sure about the changes to `ci.yaml`, so let me know if you want those reverted / changed somehow!