### PR TITLE
Add support for LLVM's freeze instruction in Uninitialized plugin

### DIFF
--- a/src/plugins/Uninitialized.cpp
+++ b/src/plugins/Uninitialized.cpp
@@ -1328,7 +1328,8 @@ void Uninitialized::instructionExecuted(const WorkItem* workItem,
   }
   case llvm::Instruction::Freeze:
   {
-    shadowValues->setValue(instruction, ShadowContext::getCleanValue(instruction));
+    shadowValues->setValue(instruction,
+                           ShadowContext::getCleanValue(instruction));
     break;
   }
   case llvm::Instruction::GetElementPtr:


### PR DESCRIPTION
Add missing support for LLVM's `freeze` instruction to Uninitialized plugin, since #195 only added support to the Oclgrind core.

Because `freeze` produces a clean value, I have adapted the plugin accordingly. To be honest, I am not entirely familiar with the implementation of Oclgrind, so hopefully this is correct in the context of the Uninitialized plugin.